### PR TITLE
Docs seem to have a typo

### DIFF
--- a/docs/md/tutorial/request.md
+++ b/docs/md/tutorial/request.md
@@ -77,7 +77,7 @@ The return value when calling an Operation is a pair of (SwaggerRequest, Swagger
 just pass it to 'request' function of client. Below is a full example of 'getUserByName'
 ```python
 from pyswagger import SwaggerApp
-from pyswagger.contrib.client.request import Client
+from pyswagger.contrib.client.requests import Client
 
 app = SwaggerApp.create('/path/to/your/resource/file/swagger.json')
 client = Client()


### PR DESCRIPTION
Changed 
When I ran the example, it looked like the `import` was missing an s

```
from pyswagger.contrib.client.request import Client
```

into 

```
from pyswagger.contrib.client.requests import Client
```