### PR TITLE
Content-Type support other than application/json

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Read the [Document](http://pyswagger.readthedocs.org/en/latest/), or just go thr
 - [Testing a Local Server](docs/md/tutorial/local.md)
 - [Converting Document into another version](docs/md/tutorial/converter.md)
 - [Exntending Primitive Factory for user-defined primitives](docs/md/tutorial/extend_prim.md)
+- [Rendering Random Requests for BlackBox Testing](docs/md/tutorial/render.md)
+- [Operation MIME Support](docs/md/tutorial/mime.md)
 
 ---------
 

--- a/docs/md/tutorial/extend_prim.md
+++ b/docs/md/tutorial/extend_prim.md
@@ -1,7 +1,7 @@
 ## Make your own primitive creater
 
 In pyswagger, there is a module designed to convert primitives in python to primitives in Swagger.
-We already supprt those primitives defined in Swagger spec, for user-defined primitives, we provide a
+We already support those primitives defined in Swagger spec, for user-defined primitives, we provide a
 way for users to provide primitives creater.
 
 Here is a simple example for primitive creater:

--- a/docs/md/tutorial/mime.md
+++ b/docs/md/tutorial/mime.md
@@ -1,0 +1,70 @@
+## Operation MIME Support
+Swagger operation may contain more than one MIME type.
+pyswagger allows you to specify consume/produce MIME type when sending request.
+Also, customized MIME codec is supported.
+
+```python
+from pyswagger import SwaggerApp
+from pyswagger.contrib.client.requests import Client
+from pyswagger.primitives import MimeCodec
+import xmltodict
+import dicttoxml
+
+
+class XmlCodec:
+    def marshal(self, value, **kwargs):  # name, _type, _format is available in kwargs
+        name = kwargs['name']
+        if name:
+            return dicttoxml.dicttoxml(value, root=True, custom_root=name, attr_type=False)
+        else:
+            return '<?xml version="1.0" encoding="UTF-8" ?>' + dicttoxml.dicttoxml(value, root=False, attr_type=False)
+
+    def unmarshal(self, data, **kwargs):  # name, _type, _format is available in kwargs
+        return xmltodict.parse(data)
+
+
+def _create_mime_codec():
+    mime_codec = MimeCodec()
+    xmlCodec = XmlCodec()
+    for _type in ['application', 'text']:
+        mime_codec.register('%s/xml' % _type, xmlCodec)
+    return mime_codec
+
+
+_mime_codec = _create_mime_codec()
+
+app = SwaggerApp.load('http://petstore.swagger.io/v2/swagger.json', mime_codec=_mime_codec)
+app.prepare(strict=True)
+placeOrder = app.op['placeOrder']
+body = dict(complete=True, id=1, petId=1, quantity=1)
+client = Client()
+
+
+def print_response(response):
+    print 'status:', response.status
+    print 'header:', response.header
+    print 'raw:', response.raw
+    print 'data:', response.data
+
+print 'consumes:', placeOrder.consumes
+print 'produces:', placeOrder.produces
+
+# default consume 'application/json', produce: 'application/xml'
+req, resp = placeOrder(body=body)
+print_response(client.request((req, resp)))
+
+# consume: 'application/xml'
+req, resp = placeOrder(body=body)
+req.consume('application/xml')
+print_response(client.request((req, resp)))
+
+# produce: 'application/json'
+req, resp = placeOrder(body=body)
+req.produce('application/json')
+print_response(client.request((req, resp)))
+
+# consume: 'application/xml', produce: 'application/json'
+req, resp = placeOrder(body=body)
+req.consume('application/xml').produce('application/json')
+print_response(client.request((req, resp)))
+```

--- a/pyswagger/contrib/client/requests.py
+++ b/pyswagger/contrib/client/requests.py
@@ -43,12 +43,12 @@ class Client(BaseClient):
             files=file_obj
         )
         rq = self.__s.prepare_request(rq)
-        rs = self.__s.send(rq)
+        rs = self.__s.send(rq, stream=True)
 
         resp.apply_with(
             status=rs.status_code,
             header=rs.headers,
-            raw=rs.text
+            raw=six.StringIO(rs.content).getvalue()
         )
 
         return resp

--- a/pyswagger/core.py
+++ b/pyswagger/core.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from .getter import UrlGetter, LocalGetter
 from .resolve import SwaggerResolver
-from .primitives import SwaggerPrimitive
+from .primitives import SwaggerPrimitive, MimeCodec
 from .spec.v1_2.parser import ResourceListContext
 from .spec.v2_0.parser import SwaggerContext
 from .spec.v2_0.objects import Operation
@@ -33,7 +33,7 @@ class SwaggerApp(object):
         sc_path: ('/', '#/paths')
     }
 
-    def __init__(self, url=None, url_load_hook=None, sep=consts.private.SCOPE_SEPARATOR, prim=None):
+    def __init__(self, url=None, url_load_hook=None, sep=consts.private.SCOPE_SEPARATOR, prim=None, mime_codec=None):
         """ constructor
 
         :param url str: url of swagger.json
@@ -66,6 +66,9 @@ class SwaggerApp(object):
 
         # init a default SwaggerPrimitive as factory for primitives
         self.__prim = prim if prim else SwaggerPrimitive()
+
+        # MIME codec
+        self.__mime_codec = mime_codec or MimeCodec()
 
     @property
     def root(self):
@@ -144,6 +147,14 @@ class SwaggerApp(object):
         :type: pyswagger.primitives.SwaggerPrimitive
         """
         return self.__prim
+
+    @property
+    def mime_codec(self):
+        """ mime codec used by this app
+
+        :type: pyswagger.primitives.MimeCodec
+        """
+        return self.__mime_codec
 
     def load_obj(self, jref, getter=None, parser=None):
         """ load a object(those in spec._version_.objects) from a JSON reference.
@@ -244,7 +255,7 @@ class SwaggerApp(object):
         return v.errs
 
     @classmethod
-    def load(kls, url, getter=None, parser=None, url_load_hook=None, sep=consts.private.SCOPE_SEPARATOR, prim=None):
+    def load(kls, url, getter=None, parser=None, url_load_hook=None, sep=consts.private.SCOPE_SEPARATOR, prim=None, mime_codec=None):
         """ load json as a raw SwaggerApp
 
         :param str url: url of path of Swagger API definition
@@ -256,6 +267,7 @@ class SwaggerApp(object):
         :param func url_load_hook: hook to patch the url to load json
         :param str sep: scope-separater used in this SwaggerApp
         :param prim pyswager.primitives.SwaggerPrimitive: factory for primitives in Swagger
+        :param mime_codec pyswagger.primitives.MimeCodec: MIME codec
         :return: the created SwaggerApp object
         :rtype: SwaggerApp
         :raises ValueError: if url is wrong
@@ -265,7 +277,7 @@ class SwaggerApp(object):
         logger.info('load with [{0}]'.format(url))
 
         url = utils.normalize_url(url)
-        app = kls(url, url_load_hook=url_load_hook, sep=sep, prim=prim)
+        app = kls(url, url_load_hook=url_load_hook, sep=sep, prim=prim, mime_codec=mime_codec)
         app.__raw, app.__version = app.load_obj(url, getter=getter, parser=parser)
         if app.__version not in ['1.2', '2.0']:
             raise NotImplementedError('Unsupported Version: {0}'.format(self.__version))

--- a/pyswagger/primitives/__init__.py
+++ b/pyswagger/primitives/__init__.py
@@ -12,8 +12,8 @@ from ._model import Model
 from ._uuid import UUID
 from .comm import create_obj, _2nd_pass_obj
 from .render import Renderer
+from .codec import MimeCodec
 import functools
-import json
 
 # TODO: enum is suitable for all types, not only string
 

--- a/pyswagger/primitives/_array.py
+++ b/pyswagger/primitives/_array.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 from ..errs import ValidationError, SchemaError
 import functools
 import six
-import json
 
 
 class Array(list):
@@ -21,19 +20,16 @@ class Array(list):
         self.__collection_format = getattr(obj, 'collectionFormat', 'csv')
 
         if isinstance(val, six.string_types):
-            try:
-                val = json.loads(val)
-            except Exception as e:
-                if self.__collection_format == 'csv':
-                    val = val.split(',')
-                elif self.__collection_format == 'ssv':
-                    val = val.split(' ')
-                elif self.__collection_format == 'tsv':
-                    val = val.split('\t')
-                elif self.__collection_format == 'pipes':
-                    val = val.split('|')
-                else:
-                    raise e
+            if self.__collection_format == 'csv':
+                val = val.split(',')
+            elif self.__collection_format == 'ssv':
+                val = val.split(' ')
+            elif self.__collection_format == 'tsv':
+                val = val.split('\t')
+            elif self.__collection_format == 'pipes':
+                val = val.split('|')
+            else:
+                raise SchemaError("Unsupported collection format '{0}' when converting array: {1}".format(self.__collection_format, val))
 
         val = set(val) if obj.uniqueItems else val
 

--- a/pyswagger/primitives/_model.py
+++ b/pyswagger/primitives/_model.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-import json
 import six
 
 class Model(dict):
@@ -19,15 +18,8 @@ class Model(dict):
         """ recursivly apply Schema object
 
         :param obj.Model obj: model object to instruct how to create this model
-        :param val: things used to construct this model
-        :type val: dict of json string in str or byte
+        :param dict val: things used to construct this model
         """
-        if isinstance(val, six.string_types):
-            val = json.loads(val)
-        elif isinstance(val, six.binary_type):
-            # TODO: encoding problem...
-            val = json.loads(val.decode('utf-8'))
-
         for k, v in six.iteritems(val):
             if k in obj.properties:
                 pobj = obj.properties.get(k)

--- a/pyswagger/primitives/codec.py
+++ b/pyswagger/primitives/codec.py
@@ -1,0 +1,53 @@
+import json
+import six
+from .comm import PrimJSONEncoder
+
+
+class MimeCodec:
+    def __init__(self):
+        self._codecs = {}
+        self.register('text/plain', PlainCodec())
+        jsonCodec = JsonCodec()
+        self.register('application/json', jsonCodec)
+        self.register('text/json', jsonCodec)
+
+    def register(self, mime, codec):
+        self._codecs[mime.lower()] = codec
+
+    def unregister(self, mime):
+        self._codecs.pop(mime.lower())
+
+    def codec(self, mime):
+        mime = mime.split(';', 1)[0]
+        mime = mime.strip().lower()
+        return self._codecs.get(mime, None)
+
+    def marshal(self, mime, value, **kwargs):
+        codec = self.codec(mime)
+        if not codec:
+            raise Exception('Could not find codec for %s, value: %s, args: %s' % (mime, value, kwargs))
+        return codec.marshal(value, **kwargs)
+
+    def unmarshal(self, mime, data, **kwargs):
+        codec = self.codec(mime)
+        if not codec:
+            raise Exception('Could not find codec for %s, data: %s, args: %s' % (mime, data, kwargs))
+        return codec.unmarshal(data, **kwargs)
+
+
+class PlainCodec:
+    def marshal(self, value, **kwargs):
+        return value
+
+    def unmarshal(self, data, **kwargs):
+        return data
+
+
+class JsonCodec:
+    def marshal(self, value, **kwargs):
+        return json.dumps(value, cls=PrimJSONEncoder)
+
+    def unmarshal(self, data, **kwargs):
+        if isinstance(data, six.binary_type):
+            data = data.decode('utf-8')
+        return json.loads(data)

--- a/pyswagger/scanner/v2_0/patch_obj.py
+++ b/pyswagger/scanner/v2_0/patch_obj.py
@@ -47,6 +47,9 @@ class PatchObject(object):
         if obj.security == None and isinstance(app.root, Swagger):
             obj.update_field('security', app.root.security)
 
+        # mime_codec
+        setattr(obj, '_mime_codec', app.mime_codec)
+
     @Disp.register([PathItem])
     def _path_item(self, path, obj, app):
         """

--- a/pyswagger/tests/contrib/client/test_requests.py
+++ b/pyswagger/tests/contrib/client/test_requests.py
@@ -69,6 +69,7 @@ class RequestsClient_Pet_TestCase(unittest.TestCase):
         """ Pet.findPetsByTags """
         httpretty.register_uri(httpretty.GET, 'http://petstore.swagger.wordnik.com/api/pet/findByTags',
             status=200,
+            content_type='application/json',
             body=json.dumps([pet_Tom, pet_Qoo])
         )
 
@@ -88,6 +89,7 @@ class RequestsClient_Pet_TestCase(unittest.TestCase):
         """ Pet.partialUpdate """
         httpretty.register_uri(httpretty.PATCH, 'http://petstore.swagger.wordnik.com/api/pet/0',
             status=200,
+            content_type='application/json',
             body=json.dumps([pet_Tom, pet_Sue])
         )
         resp = client.request(app.op['partialUpdate'](
@@ -139,6 +141,7 @@ class RequestsClient_Pet_TestCase(unittest.TestCase):
         """ Pet.getPetById """
         httpretty.register_uri(httpretty.GET, 'http://petstore.swagger.wordnik.com/api/pet/1',
             status=200,
+            content_type='application/json',
             body=json.dumps(pet_Tom)
         )
 

--- a/pyswagger/tests/test_codec.py
+++ b/pyswagger/tests/test_codec.py
@@ -1,0 +1,30 @@
+from __future__ import absolute_import
+from pyswagger.primitives import MimeCodec
+import unittest
+
+
+class CodecTestCase(unittest.TestCase):
+    def test_register_unregister(self):
+        mime_codec = MimeCodec()
+        mime = 'test'
+        dummy_codec = {}
+        self.assertEqual(None, mime_codec.codec(mime))
+        mime_codec.register(mime, dummy_codec)
+        self.assertEqual(dummy_codec, mime_codec.codec(mime))
+        mime_codec.unregister(mime)
+        self.assertEqual(None, mime_codec.codec(mime))
+
+    def test_plain_codec(self):
+        mime_codec = MimeCodec()
+        mime = 'text/plain'
+        text = 'plain text'
+        self.assertEqual(text, mime_codec.marshal(mime, text))
+        self.assertEqual(text, mime_codec.unmarshal(mime, text))
+
+    def test_json_codec(self):
+        mime_codec = MimeCodec()
+        mime = 'application/json'
+        value = dict(key='value')
+        data = '{"key": "value"}'
+        self.assertEqual(data, mime_codec.marshal(mime, value))
+        self.assertEqual(value, mime_codec.unmarshal(mime, data))

--- a/pyswagger/tests/v1_2/test_io.py
+++ b/pyswagger/tests/v1_2/test_io.py
@@ -3,6 +3,7 @@ from ..utils import get_test_data_folder
 from pyswagger.primitives import Model, Array
 from pyswagger.io import SwaggerRequest
 import unittest
+import json
 
 
 app = SwaggerApp._create_(get_test_data_folder(version='1.2', which='wordnik')) 
@@ -187,10 +188,12 @@ class SwaggerResponse_TestCase(unittest.TestCase):
         """ Pet.findPetsByTags """
         _, resp = app.op['findPetsByTags'](tags=[])
 
-        resp.apply_with(status=200, raw=[
+        raw = json.dumps([
             dict(id=1, name='Tom', category=dict(id=1, name='dog'), tags=[dict(id=1, name='small')]),
             dict(id=2, name='QQ', tags=[dict(id=1, name='small')])
         ])
+
+        resp.apply_with(status=200, raw=raw)
 
         d = resp.data
         self.assertTrue(isinstance(d, Array))

--- a/pyswagger/tests/v1_2/test_model.py
+++ b/pyswagger/tests/v1_2/test_model.py
@@ -29,6 +29,7 @@ class ModelInteritanceTestCase(unittest.TestCase):
         httpretty.register_uri(
             httpretty.GET, 'http://petstore.swagger.wordnik.com/api/user/mary',
             status=200,
+            content_type='application/json',
             body=json.dumps(uwi_mary)
             )
 
@@ -50,6 +51,7 @@ class ModelInteritanceTestCase(unittest.TestCase):
         httpretty.register_uri(
             httpretty.GET, 'http://petstore.swagger.wordnik.com/api/user/kevin',
             status=200,
+            content_type='application/json',
             body=json.dumps(uwi_kevin)
             )
 

--- a/pyswagger/tests/v2_0/test_io.py
+++ b/pyswagger/tests/v2_0/test_io.py
@@ -16,19 +16,21 @@ class SwaggerResponseTestCase(unittest.TestCase):
 
     def test_response_schema_with_status(self):
         """ make sure schema works as expected """
-        resp = io.SwaggerResponse(self.app.s('/resp').get)
 
         # make sure exception raised
+        resp = io.SwaggerResponse(self.app.s('/resp').get)
         self.assertRaises(Exception, resp.apply_with, None, 'some string')
 
         # test for 'default'
-        resp.apply_with(0, 'test string')
+        resp = io.SwaggerResponse(self.app.s('/resp').get)
+        resp.apply_with(0, 'test string', {'content-type': 'text/plain'})
         self.assertEqual(resp.status, 0)
         self.assertEqual(resp.raw, 'test string')
         self.assertEqual(resp.data, 'test string')
 
         # test for specific status code
         r = '{"id": 0, "message": "test string 2"}'
+        resp = io.SwaggerResponse(self.app.s('/resp').get)
         resp.apply_with(404, r)
         self.assertEqual(resp.status, 404)
         self.assertEqual(resp.raw, r)


### PR DESCRIPTION
pyswagger requires swagger operation consume and produce in application/json format. To support other content-type (application/xml, application/x-protobuf, etc.), I draft a commit.

Here is my usage:
```python
class XmlCodec:
    def marshal(self, _type, _format, value):
        return '<?xml version="1.0" encoding="UTF-8" ?>' + dicttoxml.dicttoxml(value, root=False, attr_type=False)

    def unmarshal(self, _type, _format, data):
        return xmltodict.parse(data)


def _create_mime_codec():
    mime_codec = MimeCodec()
    xmlCodec = XmlCodec()
    for _type in ['application', 'text']:
        mime_codec.register('%s/xml' % _type, xmlCodec)
    return mime_codec


_mime_codec = _create_mime_codec()

app = SwaggerApp.load(filepath, mime_codec=_mime_codec)
client = Client()
op = app.op['op']
pet_Tom=dict(id=1, name='Tom', photoUrls=['http://test'])
# use default/first consume/produce
client.request(op(body=pet_Tom))
# consume 'application/xml'
client.request(op('application/xml', body=pet_Tom))
# consume 'application/xml', produce 'application/json'
client.request(op('application/xml', 'application/json', body=pet_Tom))
```
