### PR TITLE
external reference to documents containing any valid json/yaml struct

### DIFF
--- a/pyswagger/io.py
+++ b/pyswagger/io.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 from .primitives.comm import PrimJSONEncoder
-from .utils import deref
+from .utils import final
 from pyswagger import errs
 from uuid import uuid4
 import six
@@ -313,8 +313,8 @@ class SwaggerResponse(object):
         if status != None:
             self.__status = status
 
-        r = (deref(self.__op.responses.get(str(self.__status), None)) or
-             deref(self.__op.responses.get('default', None)))
+        r = (final(self.__op.responses.get(str(self.__status), None)) or
+             final(self.__op.responses.get('default', None)))
 
         if raw != None:
             # update 'raw'

--- a/pyswagger/primitives/render.py
+++ b/pyswagger/primitives/render.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 from ..spec.v2_0.objects import Parameter, Operation, Schema
-from ..utils import deref, from_iso8601
+from ..utils import deref, final, from_iso8601
 from decimal import Decimal
 import random
 import six
@@ -167,8 +167,7 @@ class Renderer(object):
         return None if r == None else r.get(_format, None)
 
     def _generate(self, obj, opt):
-        obj = deref(obj)
-        obj = obj.final if isinstance(obj, Schema) else obj
+        obj = final(deref(obj))
         type_ = getattr(obj, 'type', None)
         template = opt['object_template']
         out = None

--- a/pyswagger/resolve.py
+++ b/pyswagger/resolve.py
@@ -1,0 +1,72 @@
+from __future__ import absolute_import
+from .utils import jr_split, jp_split
+from .getter import UrlGetter, LocalGetter
+import six
+import os
+import inspect
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+class SwaggerResolver(object):
+    """ JSON Reference Resolver:
+    resolving a JSON reference to a raw object (dict),
+    then return and cache it.
+    """
+
+    def __init__(self, url_load_hook):
+        """
+        """
+        # a map from url to loaded json/yaml
+        self.__cache = {}
+
+        # things to make unittest easier,
+        # all urls to load json would go through this hook
+        self.__url_load_hook = url_load_hook
+
+    def resolve(self, jref, getter=None):
+        """
+        """
+        url, jp = jr_split(jref)
+
+        # apply hook when use this url to load
+        # note that we didn't cache SwaggerApp with this local_url
+        local_url = self.__url_load_hook(url) if self.__url_load_hook else url
+
+        logger.info('{0} patch to {1}'.format(url, local_url))
+
+        # check cache
+        obj = self.__cache.get(url, None)
+        if not obj:
+            # load that object
+            if not getter:
+                getter = UrlGetter
+                p = six.moves.urllib.parse.urlparse(local_url)
+                if p.scheme == 'file' and p.path:
+                    getter = LocalGetter(os.path.join(p.netloc, p.path))
+
+            if inspect.isclass(getter):
+                # default initialization is passing the url
+                # you can override this behavior by passing an
+                # initialized getter object.
+                getter = getter(local_url)
+
+            obj = six.advance_iterator(getter)
+            self.__cache[url] = obj if obj else None
+
+        if obj:
+            ts = jp_split(jp)[1:]
+            while len(ts) > 0:
+                t = ts.pop(0)
+                if isinstance(obj, list):
+                    obj = obj[int(t)]
+                elif isinstance(obj, dict):
+                    obj = obj[t]
+                else:
+                    raise Exception('Invalid type to resolve json-pointer: {0}'.format(str(type(obj))))
+        else:
+            raise Exception('Unable to resolve: {0}'.format(jref))
+
+        return obj

--- a/pyswagger/scanner/v2_0/__init__.py
+++ b/pyswagger/scanner/v2_0/__init__.py
@@ -3,3 +3,5 @@ from .resolve import Resolve
 from .patch_obj import PatchObject
 from .yaml import YamlFixer
 from .aggt import Aggregate
+from .norm_ref import NormalizeRef
+from .merge import Merge

--- a/pyswagger/scanner/v2_0/merge.py
+++ b/pyswagger/scanner/v2_0/merge.py
@@ -1,0 +1,60 @@
+from __future__ import absolute_import
+from ...errs import CycleDetectionError
+from ...scan import Dispatcher
+from ...spec.v2_0.parser import (
+    ParameterContext,
+    ResponseContext,
+    PathItemContext
+    )
+from ...spec.v2_0.objects import (
+    Parameter,
+    Response,
+    PathItem,
+    )
+from ...spec.base import NullContext
+from ...utils import CycleGuard
+
+
+def _merge(obj, app, creator, parser):
+    """ resolve $ref, and inject/merge referenced object to self.
+    This operation should be carried in a cascade manner.
+    """
+    result = creator(NullContext())
+    result.merge(obj, parser)
+
+    guard = CycleGuard()
+    guard.update(obj)
+
+    r = getattr(obj, '$ref')
+    while r and len(r) > 0:
+        ro = app.resolve(r, parser)
+        if ro.__class__ != obj.__class__:
+            raise TypeError('Referenced Type mismatch: {0}'.format(r))
+        try:
+            guard.update(ro)
+        except CycleDetectionError:
+            # avoid infinite loop,
+            # cycle detection has a dedicated scanner.
+            break
+
+        result.merge(ro, parser)
+        r = getattr(ro, '$ref')
+    return result
+
+class Merge(object):
+    """ pre-merge these objects with '$ref' """
+
+    class Disp(Dispatcher): pass
+
+    @Disp.register([Parameter])
+    def _parameter(self, _, obj, app):
+        obj.update_field('final', _merge(obj, app, Parameter, ParameterContext))
+
+    @Disp.register([Response])
+    def _response(self, _, obj, app):
+        obj.update_field('final', _merge(obj, app, Response, ResponseContext))
+
+    @Disp.register([PathItem])
+    def _path_item(self, _, obj, app):
+        obj.merge(_merge(obj, app, PathItem, PathItemContext), PathItemContext)
+

--- a/pyswagger/scanner/v2_0/norm_ref.py
+++ b/pyswagger/scanner/v2_0/norm_ref.py
@@ -1,0 +1,22 @@
+from __future__ import absolute_import
+from ...scan import Dispatcher
+from ...utils import normalize_jr
+from ...spec.v2_0.objects import (
+    Schema,
+    Parameter,
+    Response,
+    PathItem,
+    )
+
+
+class NormalizeRef(object):
+    """ normalized all $ref """
+
+    class Disp(Dispatcher): pass
+
+    def __init__(self, base_url):
+        self.base_url = base_url
+
+    @Disp.register([Schema, Parameter, Response, PathItem])
+    def _resolve(self, path, obj, _):
+        obj.update_field('$ref', normalize_jr(getattr(obj, '$ref'), self.base_url))

--- a/pyswagger/scanner/v2_0/resolve.py
+++ b/pyswagger/scanner/v2_0/resolve.py
@@ -1,79 +1,29 @@
 from __future__ import absolute_import
+from ...errs import CycleDetectionError
 from ...scan import Dispatcher
-from ...spec.v2_0.parser import (
-    SchemaContext,
-    ParameterContext,
-    ResponseContext,
-    PathItemContext
-    )
-from ...spec.v2_0.objects import (
-    Schema,
-    Parameter,
-    Response,
-    PathItem,
-    )
-from ...utils import normalize_jr
-
-
-def is_resolved(obj):
-    return getattr(obj, '$ref') == None or obj.ref_obj != None
-
-def _resolve(obj, app, parser):
-    if is_resolved(obj):
-        return
-
-    r = getattr(obj, '$ref')
-    ro = app.resolve(normalize_jr(r, app.url), parser)
-
-    if not ro:
-        raise ReferenceError('Unable to resolve: {0}'.format(r))
-    if ro.__class__ != obj.__class__:
-        raise TypeError('Referenced Type mismatch: {0}'.format(r))
-
-    obj.update_field('ref_obj', ro)
-    obj.update_field('norm_ref', normalize_jr(r, app.url))
-
-def _merge(obj, app, ctx):
-    """ resolve $ref as ref_obj, and merge ref_obj to self.
-    This operation should be carried in a cascade manner.
-    """
-
-    cur = obj
-    to_resolve = []
-    while not is_resolved(cur):
-        _resolve(cur, app, ctx)
-
-        to_resolve.append(cur)
-        cur = cur.ref_obj if cur.ref_obj else cur
-
-    while (len(to_resolve)):
-        o = to_resolve.pop()
-        o.merge(o.ref_obj, ctx, exclude=['$ref'])
-
+from ...spec.v2_0.parser import SchemaContext
+from ...spec.v2_0.objects import Schema
 
 class Resolve(object):
     """ pre-resolve '$ref' """
 
     class Disp(Dispatcher): pass
 
-
     @Disp.register([Schema])
     def _schema(self, _, obj, app):
-        _resolve(obj, app, SchemaContext)
+        if obj.ref_obj:
+            return
 
-    @Disp.register([Parameter])
-    def _parameter(self, _, obj, app):
-        _resolve(obj, app, ParameterContext)
+        r = getattr(obj, '$ref')
+        if not r:
+            return
 
-    @Disp.register([Response])
-    def _response(self, _, obj, app):
-        _resolve(obj, app, ResponseContext)
+        ro = app.resolve(r, SchemaContext)
+        if not ro:
+            raise ReferenceError('Unable to resolve: {0}'.format(r))
+        if ro.__class__ != obj.__class__:
+            raise TypeError('Referenced Type mismatch: {0}'.format(r))
 
-    @Disp.register([PathItem])
-    def _path_item(self, _, obj, app):
+        obj.update_field('ref_obj', ro)
 
-        # $ref in PathItem is 'merge', not 'replace'
-        # we need to merge properties of others if missing
-        # in current object.
-        _merge(obj, app, PathItemContext)
 

--- a/pyswagger/spec/v2_0/objects.py
+++ b/pyswagger/spec/v2_0/objects.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 from ..base import BaseObj, FieldMeta
-from ...utils import deref
+from ...utils import final
 from ...io import SwaggerRequest, SwaggerResponse
 from ...primitives import Array
 import six
@@ -85,7 +85,6 @@ class Schema(six.with_metaclass(FieldMeta, BaseSchema)):
         # pyswagger only
         'ref_obj': None,
         'final': None,
-        'norm_ref': None,
         'name': None,
     }
 
@@ -177,9 +176,7 @@ class Parameter(six.with_metaclass(FieldMeta, BaseSchema)):
     }
 
     __internal_fields__ = {
-        # pyswagger only
-        'ref_obj': None,
-        'norm_ref': None,
+        'final': None,
     }
 
     def _prim_(self, v, prim_factory):
@@ -216,8 +213,7 @@ class Response(six.with_metaclass(FieldMeta, BaseObj_v2_0)):
     }
 
     __internal_fields__ = {
-        'ref_obj': None,
-        'norm_ref': None,
+        'final': None,
     }
 
 
@@ -281,7 +277,7 @@ class Operation(six.with_metaclass(FieldMeta, BaseObj_v2_0)):
             names.append(p.name)
 
         for p in self.parameters:
-            _convert_parameter(deref(p))
+            _convert_parameter(final(p))
 
         # check for unknown parameter
         unknown = set(six.iterkeys(k)) - set(names)
@@ -308,11 +304,6 @@ class PathItem(six.with_metaclass(FieldMeta, BaseObj_v2_0)):
         'head': None,
         'patch': None,
         'parameters': [],
-    }
-
-    __internal_fields__ = {
-        'ref_obj': None,
-        'norm_ref': None,
     }
 
 

--- a/pyswagger/tests/data/v2_0/ex/reuse/definitions/definitions/models.json
+++ b/pyswagger/tests/data/v2_0/ex/reuse/definitions/definitions/models.json
@@ -1,7 +1,7 @@
 {
   "models": {
     "Model": {
-      "description": "A simple model",
+      "description": "Another simple model",
       "type": "object",
       "properties": {
         "id": {
@@ -22,9 +22,6 @@
           "type": "string"
         }
       }
-    },
-    "QQ": {
-        "$ref":"definitions/models.json#/models/Model"
     }
   }
 }

--- a/pyswagger/tests/data/v2_0/ex/reuse/definitions/models.json
+++ b/pyswagger/tests/data/v2_0/ex/reuse/definitions/models.json
@@ -1,0 +1,27 @@
+{
+  "models": {
+    "Model": {
+      "description": "A simple model",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "tag": {
+          "description": "a complex, shared property.  Note the absolute reference",
+          "$ref": "models.json#/models/Tag"
+        }
+      }
+    },
+    "Tag": {
+      "description": "A tag entity in the system",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/pyswagger/tests/data/v2_0/ex/reuse/operations.json
+++ b/pyswagger/tests/data/v2_0/ex/reuse/operations.json
@@ -1,0 +1,23 @@
+{
+  "health": {
+    "get": {
+      "tags": [
+        "admin"
+      ],
+      "summary": "Returns server health information",
+      "operationId": "getHealth",
+      "produces": [
+        "application/json"
+      ],
+      "parameters": [],
+      "responses": {
+        "200": {
+          "description": "Health information from the server",
+          "schema": {
+            "$ref": "definitions/models.json#/models/Tag"
+          }
+        }
+      }
+    }
+  }
+}

--- a/pyswagger/tests/data/v2_0/ex/reuse/parameters/parameters.json
+++ b/pyswagger/tests/data/v2_0/ex/reuse/parameters/parameters.json
@@ -1,0 +1,22 @@
+{
+  "query" : {
+    "skip": {
+      "name": "skip",
+      "in": "query",
+      "description": "Results to skip when paginating through a result set",
+      "required": false,
+      "minimum": 0,
+      "type": "integer",
+      "format": "int32"
+    },
+    "limit": {
+      "name": "limit",
+      "in": "query",
+      "description": "Maximum number of results to return",
+      "required": false,
+      "minimum": 0,
+      "type": "integer",
+      "format": "int32"
+    }
+  }
+}

--- a/pyswagger/tests/data/v2_0/ex/reuse/responses.json
+++ b/pyswagger/tests/data/v2_0/ex/reuse/responses.json
@@ -1,0 +1,8 @@
+{
+  "NotFoundError": {
+    "description": "Entity not found",
+    "schema": {
+      "$ref": "definitions/models.json#/models/Model"
+    }
+  }
+}

--- a/pyswagger/tests/data/v2_0/ex/reuse/swagger.json
+++ b/pyswagger/tests/data/v2_0/ex/reuse/swagger.json
@@ -57,6 +57,9 @@
    "definitions":{
       "User":{
          "$ref":"definitions/models.json#/models/Model"
+      },
+      "QQ":{
+         "$ref":"definitions/models.json#/models/QQ"
       }
    }
 }

--- a/pyswagger/tests/data/v2_0/ex/reuse/swagger.json
+++ b/pyswagger/tests/data/v2_0/ex/reuse/swagger.json
@@ -1,0 +1,62 @@
+{
+   "swagger":"2.0",
+   "host":"test.com",
+   "basePath":"/v1",
+   "produces":[
+      "application/json"
+   ],
+   "consumes":[
+      "application/json"
+   ],
+   "schemes":[
+      "http",
+      "https"
+   ],
+   "paths":{
+      "/pets":{
+         "get":{
+            "description":"Returns all pets from the system that the user has access to",
+            "produces":[
+               "application/json"
+            ],
+            "parameters":[
+               {
+                  "$ref":"parameters/parameters.json#/query/skip"
+               },
+               {
+                  "$ref":"parameters/parameters.json#/query/limit"
+               },
+               {
+                  "in":"query",
+                  "name":"type",
+                  "description":"the types of pet to return",
+                  "required":false,
+                  "type":"string"
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"A list of pets.",
+                  "schema":{
+                     "type":"array",
+                     "items":{
+                        "$ref":"#/definitions/User"
+                     }
+                  }
+               },
+               "400":{
+                  "$ref":"responses.json#/NotFoundError"
+               }
+            }
+         }
+      },
+      "/health":{
+         "$ref":"operations.json#/health"
+      }
+   },
+   "definitions":{
+      "User":{
+         "$ref":"definitions/models.json#/models/Model"
+      }
+   }
+}

--- a/pyswagger/tests/data/v2_0/resolve/other/swagger.json
+++ b/pyswagger/tests/data/v2_0/resolve/other/swagger.json
@@ -39,7 +39,7 @@
    },
    "responses":{
       "r1":{
-         "description":"void"
+         "description":"void, r1"
       }
    }
 }

--- a/pyswagger/tests/test_utils.py
+++ b/pyswagger/tests/test_utils.py
@@ -124,10 +124,7 @@ class SwaggerUtilsTestCase(unittest.TestCase):
             '', '#'))
 
     def test_cycle_guard(self):
-        def my_id(obj):
-            return obj
-
-        c = utils.CycleGuard(identity_hook=my_id)
+        c = utils.CycleGuard()
         c.update(1)
         self.assertRaises(errs.CycleDetectionError, c.update, 1)
 

--- a/pyswagger/tests/test_utils.py
+++ b/pyswagger/tests/test_utils.py
@@ -189,7 +189,7 @@ class SwaggerUtilsTestCase(unittest.TestCase):
 
         # test include
         self.assertEqual(sorted(utils._diff_(dict3, dict4, include=['a'])), sorted([
-            ('a/a', 1, 2), ('a/b', 3, 2), ('a/c', 4, 5)
+            ('a/a', 1, 2)
         ]))
         # test exclude
         self.assertEqual(sorted(utils._diff_(dict3, dict4, exclude=['a'])), sorted([
@@ -210,6 +210,19 @@ class SwaggerUtilsTestCase(unittest.TestCase):
         setattr(a.b.c, 'd', 'test string')
         self.assertEqual(utils.get_or_none(a, 'b', 'c', 'd'), 'test string')
         self.assertEqual(utils.get_or_none(a, 'b', 'c', 'd', 'e'), None)
+
+    def test_url_dirname(self):
+        """ test url_dirname
+        """
+        self.assertEqual(utils.url_dirname('https://localhost/test/swagger.json'), 'https://localhost/test')
+        self.assertEqual(utils.url_dirname('https://localhost/test/'), 'https://localhost/test/')
+        self.assertEqual(utils.url_dirname('https://localhost/test'), 'https://localhost/test')
+
+    def test_url_join(self):
+        """ test url_join
+        """
+        self.assertEqual(utils.url_join('https://localhost/test', 'swagger.json'), 'https://localhost/test/swagger.json')
+        self.assertEqual(utils.url_join('https://localhost/test/', 'swagger.json'), 'https://localhost/test/swagger.json')
 
 
 class WalkTestCase(unittest.TestCase):

--- a/pyswagger/tests/v1_2/test_upgrade.py
+++ b/pyswagger/tests/v1_2/test_upgrade.py
@@ -91,7 +91,7 @@ class Swagger_Upgrade_TestCase(unittest.TestCase):
         r = o.responses['default']
         self.assertEqual(r.headers, {})
         self.assertEqual(r.schema.type, 'array')
-        self.assertEqual(getattr(r.schema.items, 'norm_ref'), _pf('/definitions/pet!##!Pet'))
+        self.assertEqual(getattr(r.schema.items, '$ref'), _pf('/definitions/pet!##!Pet'))
 
         # createUser
         o = self.app.root.paths['/api/user'].post
@@ -121,7 +121,7 @@ class Swagger_Upgrade_TestCase(unittest.TestCase):
         p = [p for p in o.parameters if getattr(p, 'in') == 'body'][0]
         self.assertEqual(getattr(p, 'in'), 'body')
         self.assertEqual(p.required, True)
-        self.assertEqual(getattr(p.schema, 'norm_ref'), _pf('/definitions/pet!##!Pet'))
+        self.assertEqual(getattr(p.schema, '$ref'), _pf('/definitions/pet!##!Pet'))
 
         # form
         o = self.app.root.paths['/api/pet/uploadImage'].post
@@ -163,7 +163,7 @@ class Swagger_Upgrade_TestCase(unittest.TestCase):
         self.assertEqual(p.maximum, 100)
 
         p = d.properties['category']
-        self.assertEqual(getattr(p, 'norm_ref'), _pf('/definitions/pet!##!Category'))
+        self.assertEqual(getattr(p, '$ref'), _pf('/definitions/pet!##!Category'))
 
         p = d.properties['photoUrls']
         self.assertEqual(p.type, 'array')
@@ -171,7 +171,7 @@ class Swagger_Upgrade_TestCase(unittest.TestCase):
 
         p = d.properties['tags']
         self.assertEqual(p.type, 'array')
-        self.assertEqual(getattr(p.items, 'norm_ref'), _pf('/definitions/pet!##!Tag'))
+        self.assertEqual(getattr(p.items, '$ref'), _pf('/definitions/pet!##!Tag'))
 
         p = d.properties['status']
         self.assertEqual(p.type, 'string')

--- a/pyswagger/tests/v2_0/test_conv.py
+++ b/pyswagger/tests/v2_0/test_conv.py
@@ -22,7 +22,7 @@ class ConverterTestCase(unittest.TestCase):
 
         # diff for empty list or dict is allowed
         d = app.dump()
-        self.assertEqual(sorted(_diff_(origin, d)), sorted([
+        self.assertEqual(sorted(_diff_(origin, d, exclude=['$ref'])), sorted([
             ('paths/~1pet~1{petId}/get/security/0/api_key', "list", "NoneType"),
             ('paths/~1store~1inventory/get/parameters', None, None),
             ('paths/~1store~1inventory/get/security/0/api_key', "list", "NoneType"),
@@ -33,7 +33,7 @@ class ConverterTestCase(unittest.TestCase):
         tmp = {'_tmp_': {}}
         with SwaggerContext(tmp, '_tmp_') as ctx:
             ctx.parse(d)
-            
+
 
 class Converter_v1_2_TestCase(unittest.TestCase):
     """ test for convert from 1.2
@@ -64,7 +64,8 @@ class Converter_v1_2_TestCase(unittest.TestCase):
         }
         self.assertEqual(_diff_(
             expect,
-            self.app.s('/api/pet/{petId}').patch.responses['default'].schema.items.dump()
+            self.app.s('/api/pet/{petId}').patch.responses['default'].schema.items.dump(),
+            exclude=['$ref'],
         ), [])
 
         # enum
@@ -248,7 +249,8 @@ class Converter_v1_2_TestCase(unittest.TestCase):
         }
         self.assertEqual(_diff_(
             expect,
-            self.app.s('/api/pet/findByTags').get.responses['default'].dump()
+            self.app.s('/api/pet/findByTags').get.responses['default'].dump(),
+            exclude=['$ref'],
         ), [])
 
     def test_property(self):
@@ -317,7 +319,8 @@ class Converter_v1_2_TestCase(unittest.TestCase):
         d = self.app.resolve('#/definitions/pet:Pet').dump()
         self.assertEqual(_diff_(
             expect,
-            self.app.resolve('#/definitions/pet:Pet').dump()
+            self.app.resolve('#/definitions/pet:Pet').dump(),
+            exclude=['$ref'],
         ), [])
 
     def test_info(self):

--- a/pyswagger/tests/v2_0/test_resolve.py
+++ b/pyswagger/tests/v2_0/test_resolve.py
@@ -30,6 +30,10 @@ class ResolvePathItemTestCase(unittest.TestCase):
         self.assertTrue(b.put.description, 'c.put')
         self.assertTrue(b.post.description, 'd.post')
 
+        c = self.app.resolve(utils.jp_compose('/c', '#/paths'))
+        self.assertTrue(b.put.description, 'c.put')
+        self.assertTrue(b.post.description, 'd.post')
+
 
 class ResolveTestCase(unittest.TestCase):
     """ test for $ref other than PathItem """

--- a/pyswagger/tests/v2_0/test_resolve.py
+++ b/pyswagger/tests/v2_0/test_resolve.py
@@ -1,6 +1,7 @@
 from pyswagger import SwaggerApp, utils
 from pyswagger.spec.v2_0 import objects
 from ..utils import get_test_data_folder
+from ...utils import final
 import unittest
 import os
 
@@ -50,13 +51,13 @@ class ResolveTestCase(unittest.TestCase):
         """ make sure $ref to Parameter works """
         p = self.app.s('/a').get
 
-        self.assertEqual(id(p.parameters[0].ref_obj), id(self.app.resolve('#/parameters/p1')))
+        self.assertEqual(final(p.parameters[0]).name, 'p1_d')
 
     def test_response(self):
         """ make sure $ref to Response works """
         p = self.app.s('/a').get
 
-        self.assertEqual(id(p.responses['default'].ref_obj), id(self.app.resolve('#/responses/r1')))
+        self.assertEqual(final(p.responses['default']).description, 'void, r1')
 
     def test_raises(self):
         """ make sure to raise for invalid input """

--- a/pyswagger/utils.py
+++ b/pyswagger/utils.py
@@ -87,15 +87,13 @@ class CycleGuard(object):
     """ Guard for cycle detection
     """
 
-    def __init__(self, identity_hook=id):
+    def __init__(self):
         self.__visited = []
-        self.__hook = identity_hook
 
     def update(self, obj):
-        i = self.__hook(obj)
-        if i in self.__visited:
+        if obj in self.__visited:
             raise CycleDetectionError('Cycle detected: {0}'.format(getattr(obj, '$ref', None)))
-        self.__visited.append(i)
+        self.__visited.append(obj)
 
 
 # TODO: this function and datetime don't handle leap-second.

--- a/pyswagger/utils.py
+++ b/pyswagger/utils.py
@@ -94,7 +94,7 @@ class CycleGuard(object):
     def update(self, obj):
         i = self.__hook(obj)
         if i in self.__visited:
-            raise CycleDetectionError('Cycle detected: {0}'.format(obj.__repr__()))
+            raise CycleDetectionError('Cycle detected: {0}'.format(getattr(obj, '$ref', None)))
         self.__visited.append(i)
 
 
@@ -259,6 +259,9 @@ def deref(obj, guard=None):
         guard.update(cur)
     return cur
 
+def final(obj):
+    return obj.final if getattr(obj, 'final', None) else obj
+
 def get_dict_as_tuple(d):
     """ get the first item in dict,
     and return it as tuple.
@@ -302,6 +305,29 @@ def normalize_url(url):
 
     return url
 
+def url_dirname(url):
+    """ Return the folder containing the '.json' file
+    """
+    p = six.moves.urllib.parse.urlparse(url)
+    for e in [private.FILE_EXT_JSON, private.FILE_EXT_YAML]:
+        if p.path.endswith(e):
+            return six.moves.urllib.parse.urlunparse(
+                p[:2]+
+                (os.path.dirname(p.path),)+
+                p[3:]
+            )
+    return url
+
+def url_join(url, path):
+    """ url version of os.path.join
+    """
+    p = six.moves.urllib.parse.urlparse(url)
+    return six.moves.urllib.parse.urlunparse(
+        p[:2]+
+        (os.path.join(p.path, path),)+
+        p[3:]
+    )
+
 def normalize_jr(jr, url=None):
     """ normalize JSON reference, also fix
     implicit reference of JSON pointer.
@@ -328,7 +354,7 @@ def normalize_jr(jr, url=None):
         if p.scheme == '' and url:
             p = six.moves.urllib.parse.urlparse(url)
             # it's the path of relative file
-            path = six.moves.urllib.parse.urlunparse(p[:2]+(os.path.join(os.path.dirname(p.path), jr),)+p[3:])
+            path = six.moves.urllib.parse.urlunparse(p[:2]+(os.path.join(os.path.dirname(p.path), path),)+p[3:])
     else:
         path = url
 
@@ -396,7 +422,6 @@ def walk(start, ofn, cyc=None):
 
     return cyc
 
-
 def _diff_(src, dst, ret=None, jp=None, exclude=[], include=[]):
     """ compare 2 dict/list, return a list containing
     json-pointer indicating what's different, and what's diff exactly.
@@ -407,10 +432,10 @@ def _diff_(src, dst, ret=None, jp=None, exclude=[], include=[]):
     - other: (jp, src, dst)
     """
 
-    def _dict_(src, dst, ret, jp, exc, inc):
+    def _dict_(src, dst, ret, jp):
         ss, sd = set(src.keys()), set(dst.keys())
         # what's include is prior to what's exclude
-        si, se = set(inc or []), set(exc or [])
+        si, se = set(include or []), set(exclude or [])
         ss, sd = (ss & si, sd & si) if si else (ss, sd)
         ss, sd = (ss - se, sd - se) if se else (ss, sd)
 
@@ -424,7 +449,7 @@ def _diff_(src, dst, ret=None, jp=None, exclude=[], include=[]):
 
         # same key
         for k in ss & sd:
-            _diff_(src[k], dst[k], ret, jp_compose(k, base=jp))
+            _diff_(src[k], dst[k], ret, jp_compose(k, base=jp), exclude, include)
 
     def _list_(src, dst, ret, jp):
         if len(src) < len(dst):
@@ -462,7 +487,7 @@ def _diff_(src, dst, ret=None, jp=None, exclude=[], include=[]):
                 ss, sd = src, dst
 
             for idx, (s, d) in enumerate(zip(src, dst)):
-                _diff_(s, d, ret, jp_compose(str(idx), base=jp))
+                _diff_(s, d, ret, jp_compose(str(idx), base=jp), exclude, include)
 
     ret = [] if ret == None else ret
     jp = '' if jp == None else jp
@@ -471,7 +496,7 @@ def _diff_(src, dst, ret=None, jp=None, exclude=[], include=[]):
         if not isinstance(dst, dict):
             ret.append((jp, type(src).__name__, type(dst).__name__,))
         else:
-            _dict_(src, dst, ret, jp, exclude, include)
+            _dict_(src, dst, ret, jp)
     elif isinstance(src, list):
         if not isinstance(dst, list):
             ret.append((jp, type(src).__name__, type(dst).__name__,))


### PR DESCRIPTION
- no more app_cache, you can’t group SwaggerApp(s) into one.
- getter would only get exact one url, __find_urls moved to ResourceListContext
- the resolving of $ref for Response, Parameter are injecting (merge), not caching.
- all $ref would be normalized to canonical form.

https://github.com/mission-liao/pyswagger/issues/53