### PR TITLE
Fix #74 Fix #17 (Better work with bytes in python3, making tests pass on python 3)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
     - "2.6"
     - "2.7"
     - "3.3"
+    - "3.5"
 install:
     - pip install -r requirements-dev.txt
     - pip install coveralls

--- a/pyswagger/contrib/client/requests.py
+++ b/pyswagger/contrib/client/requests.py
@@ -10,19 +10,25 @@ class Client(BaseClient):
 
     __schemes__ = set(['http', 'https'])
 
-    def __init__(self, auth=None, send_opt={}):
+    def __init__(self, auth=None, send_opt=None):
         """ constructor
 
         :param auth pyswagger.SwaggerAuth: auth info used when requesting
         :param send_opt dict: options used in requests.send, ex verify=False
         """
         super(Client, self).__init__(auth)
+        if send_opt is None:
+            send_opt = {}
+
         self.__s = Session()
         self.__send_opt = send_opt
 
-    def request(self, req_and_resp, opt={}):
+    def request(self, req_and_resp, opt=None):
         """
         """
+        if opt is None:
+            opt = {}
+
         req, resp = super(Client, self).request(req_and_resp, opt)
 
         # apply request-related options before preparation.
@@ -52,7 +58,7 @@ class Client(BaseClient):
         resp.apply_with(
             status=rs.status_code,
             header=rs.headers,
-            raw=six.StringIO(rs.content).getvalue()
+            raw=six.BytesIO(rs.content).getvalue()
         )
 
         return resp

--- a/pyswagger/core.py
+++ b/pyswagger/core.py
@@ -551,7 +551,10 @@ class BaseClient(object):
 
         :param pyswagger.io.SwaggerRequest req: current request object
         """
-        ret = self.__schemes__ & set(req.schemes)
+
+        # fix test bug when in python3 scheme, more details in commint msg
+        ret = sorted(self.__schemes__ & set(req.schemes), reverse=True)
+
         if len(ret) == 0:
             raise ValueError('No schemes available: {0}'.format(req.schemes))
         return ret

--- a/pyswagger/tests/contrib/client/test_flask.py
+++ b/pyswagger/tests/contrib/client/test_flask.py
@@ -4,8 +4,6 @@ from pyswagger.contrib.client.flask import FlaskTestClient
 from ...utils import create_pet_db, get_test_data_folder, pet_Mary
 from flask import Flask, json, request
 import unittest
-import pytest
-import sys
 import six
 
 
@@ -65,7 +63,6 @@ def pet_image():
 #
 # test case
 #
-@pytest.mark.skipif(sys.version_info[:2] >= (3, 4), reason='httpretty corrupt tornado.testing in python3.4')
 class FlaskTestCase(unittest.TestCase):
     """
     """
@@ -125,4 +122,3 @@ class FlaskTestCase(unittest.TestCase):
         self.assertEqual(resp.status, 200)
         self.assertEqual(received_file.decode(), 'a test Content')
         self.assertEqual(received_meta, 'a test file')
-

--- a/pyswagger/tests/contrib/client/test_requests.py
+++ b/pyswagger/tests/contrib/client/test_requests.py
@@ -7,8 +7,6 @@ import unittest
 import httpretty
 import json
 import six
-import pytest
-import sys
 
 
 app = SwaggerApp._create_(get_test_data_folder(version='1.2', which='wordnik')) 
@@ -22,7 +20,6 @@ pet_Kay = dict(id=4, name='Kay', category=dict(id=2, name='cat'), status='availa
 pet_QQQ = dict(id=1, name='QQQ', category=dict(id=1, name='dog'), tags=None, status=None)
 
 
-@pytest.mark.skipif(sys.version_info[:2] >= (3, 3), reason='httpretty corrupt in python3')
 @httpretty.activate
 class RequestsClient_Pet_TestCase(unittest.TestCase):
     """ test SwaggerClient implemented by requests """
@@ -170,7 +167,6 @@ class RequestsClient_Pet_TestCase(unittest.TestCase):
         self.assertTrue(body.find('a test Content') != -1)
         self.assertTrue(body.find('filename="test.txt"') != -1)
 
-@pytest.mark.skipif(sys.version_info[:2] >= (3, 3), reason='httpretty corrupt in python3')
 @httpretty.activate
 class RequestsOptTestCase(unittest.TestCase):
     """ make sure that passing options to requests won't fail """
@@ -193,4 +189,3 @@ class RequestsOptTestCase(unittest.TestCase):
         self.assertEqual(resp.data,
             {u'name': 'Tom', u'tags': [{u'id': 0, u'name': 'available'}, {u'id': 1, u'name': 'sold'}], u'id': 1}
             )
-

--- a/pyswagger/tests/contrib/client/test_tornado.py
+++ b/pyswagger/tests/contrib/client/test_tornado.py
@@ -5,8 +5,6 @@ from pyswagger import SwaggerApp
 from pyswagger.contrib.client.tornado import TornadoClient
 from ...utils import create_pet_db, get_test_data_folder, pet_Mary
 import json
-import sys
-import pytest
 import six
 
 
@@ -99,7 +97,6 @@ app = web.Application([
 ], debug=True)
 
 
-@pytest.mark.skipif(sys.version_info[:2] >= (3, 3), reason='httpretty corrupt in python3')
 class TornadoTestCase(testing.AsyncHTTPTestCase):
     """
     """

--- a/pyswagger/tests/v1_2/test_app.py
+++ b/pyswagger/tests/v1_2/test_app.py
@@ -8,11 +8,8 @@ import unittest
 import httpretty
 import os
 import six
-import pytest
-import sys
 
 
-@pytest.mark.skipif(sys.version_info[:2] >= (3, 3), reason='httpretty corrupt in python3')
 class HTTPGetterTestCase(unittest.TestCase):
     """ test HTTPGetter """
 

--- a/pyswagger/tests/v1_2/test_model.py
+++ b/pyswagger/tests/v1_2/test_model.py
@@ -17,7 +17,6 @@ uwi_mary = dict(id=2, username='mary', password='456456', email='m@a.ry', phone=
 uwi_kevin = dict(id=3, username='kevin')
 
 
-@pytest.mark.skipif(sys.version_info[:2] >= (3, 3), reason='httpretty corrupt in python3')
 class ModelInteritanceTestCase(unittest.TestCase):
     """ test cases for model inheritance """
 
@@ -77,4 +76,3 @@ class ModelInteritanceTestCase(unittest.TestCase):
         self.assertEqual(m.sub_type, 'User')
         self.assertRaises(KeyError, getattr, m, 'email')
         self.assertRaises(KeyError, getattr, m, 'email')
-


### PR DESCRIPTION
Better work with bytes in python3, making tests pass on python 3
Fix #74
 raw=six.StringIO(rs.content).getvalue() replaced with  raw=six.BytesIO(rs.content).getvalue()

 Because:

 ```python
  @property
     def content(self):
         """Content of the response, in bytes."""
 ```

 And with six documentation:

  ```
  six.BytesIO
  This is a fake file object for binary data. In Python 2, it’s an alias for StringIO.StringIO, but in Python 3, it’s an alias for io.BytesIO.
  ```

  Also changed mutable parameters in contrib/requests.py to None with create new dict if none

Fix #17

in core.py
ret = self.__schemes__ & set(req.schemes) replaced with ret = sorted(self.__schemes__ & set(req.schemes), reverse=True)

because set unordable and keep {'http', 'https'} so sometime in tests was requests to https:// sometimes to http://

In case of https:// requests, httppretty tried to make real connect because only http:// url was mocked. So no prepare_sheme returns sorted list not a set and only http:// requests will be used in tests.

 prepare_scheme used only in clients and make pop with result so it will work also for lists

 So skiptest for python3 removed because now it works.

 Added python 3.5 in travis.yml