### PR TITLE
Resolve the parameter when preparing request body

### DIFF
--- a/pyswagger/io.py
+++ b/pyswagger/io.py
@@ -73,6 +73,7 @@ class Request(object):
         # according to spec, payload should be one and only,
         # so we just return the first value in dict.
         for parameter in self.__op.parameters:
+            parameter = final(parameter)
             if getattr(parameter, 'in') == 'body':
                 schema = deref(parameter.schema)
                 _type = schema.type


### PR DESCRIPTION
Request has empty HTTP body If a body parameter is defined with a $ref. This patch takes the resolved parameter values to fix this issue. I am not sure on how to write a test for this by providing schema in code.