### PR TITLE
Fix `Bytes` class `to_json` to return a string

### DIFF
--- a/pyswagger/primitives/_byte.py
+++ b/pyswagger/primitives/_byte.py
@@ -26,6 +26,6 @@ class Byte(object):
         """ according to https://github.com/wordnik/swagger-spec/issues/50,
         we should exchange 'byte' type via base64 encoding.
         """
-        return base64.urlsafe_b64encode(self.v)
+        return base64.urlsafe_b64encode(self.v).decode('utf-8')
 
 

--- a/pyswagger/tests/v2_0/test_prim.py
+++ b/pyswagger/tests/v2_0/test_prim.py
@@ -147,7 +147,7 @@ class SchemaTestCase(unittest.TestCase):
 
         bv = b._prim_("BBBBB", self.app.prim_factory)
         self.assertEqual(str(bv), "BBBBB", self.app.prim_factory)
-        self.assertEqual(bv.to_json(), six.b("QkJCQkI="))
+        self.assertEqual(bv.to_json(), "QkJCQkI=")
 
     def test_date(self):
         """ test date """


### PR DESCRIPTION
Fixes #120 

There was already a test for this, but expecting the `to_json` method to return `bytes`, so I just altered it to expect a string, and decoded the output of `base64.urlsafe_b64encode`.

I ran the tests and they all passed on Python 3.5 - I'll let Travis test on other versions.