### PR TITLE
Fix NameError when unsupported UUID type is passed to primitive factory

### DIFF
--- a/pyswagger/primitives/_uuid.py
+++ b/pyswagger/primitives/_uuid.py
@@ -30,4 +30,4 @@ class UUID(object):
             # TODO: how to support bytes_le?
             self.v = uuid.UUID(bytes=val)
         else:
-            raise ValueError('Unrecognized type for UUID: ' + str(type(v)))
+            raise ValueError('Unrecognized type for UUID: ' + str(type(val)))

--- a/pyswagger/tests/v2_0/test_prim.py
+++ b/pyswagger/tests/v2_0/test_prim.py
@@ -205,6 +205,9 @@ class SchemaTestCase(unittest.TestCase):
         self.assertTrue(isinstance(dv, primitives.UUID), 'should be an primitives.UUID, not {0}'.format(dv))
         self.assertEqual(dv.v.bytes, six.b('\x78\x56\x34\x12\x34\x12\x78\x56\x12\x34\x56\x78\x12\x34\x56\x78'))
 
+        # unsupported type - e.g. int
+        self.assertRaises(ValueError, d._prim_, 123, self.app.prim_factory)
+
     def test_read_only(self):
         """ make sure read-only for property works """
         op = self.app.s('/k').post


### PR DESCRIPTION
Hi,

This is just a small bug, so I've not raised an issue for it - hope that's ok. This change fixes the error shown in the stack trace below so that the correct exception is raised.

Fix is just to use the correct variable name, and  I added a test to verify the fix.

```python
  File "C:\Program Files (x86)\Python 3.5\lib\site-packages\pyswagger\primitives\comm.py", line 40, in _2nd_pass_obj
    return ret.apply_with(obj, val, ctx)
  File "C:\Program Files (x86)\Python 3.5\lib\site-packages\pyswagger\primitives\_uuid.py", line 33, in apply_with
    raise ValueError('Unrecognized type for UUID: ' + str(type(v)))
NameError: name 'v' is not defined
```
