### PR TITLE
Allow to render request for parameters without 'format'

### DIFF
--- a/pyswagger/primitives/render.py
+++ b/pyswagger/primitives/render.py
@@ -135,10 +135,14 @@ class Renderer(object):
         # init map of generators
         self._map = {
             'integer': {
+                '': _int_,
+                None: _int_,
                 'int32': _int_,
                 'int64': _int_,
             },
             'number': {
+                '': _float_,
+                None: _float_,
                 'float': _float_,
                 'double': _float_,
             },

--- a/pyswagger/tests/data/v2_0/render/other/swagger.json
+++ b/pyswagger/tests/data/v2_0/render/other/swagger.json
@@ -24,12 +24,18 @@
             }
          ]
       },
+      "float.2":{
+         "type":"number"
+      },
       "integer.1":{
          "type":"integer",
          "format":"int32",
          "maximum":50,
          "minimum":10,
          "multipleOf":5
+      },
+      "integer.2":{
+         "type":"integer"
       },
       "enum.string":{
          "type":"string",

--- a/pyswagger/tests/test_render.py
+++ b/pyswagger/tests/test_render.py
@@ -123,6 +123,14 @@ class OtherTestCase(unittest.TestCase):
             self.assertTrue(i >= 10, 'should be greater than 10, not {0}'.format(i))
             self.assertTrue((i % 5) == 0, 'should be moduleable by 5, not {0}'.format(i))
 
+    def test_integer_without_format(self):
+        for _ in six.moves.xrange(50):
+            i = self.rnd.render(
+                self.app.resolve('#/definitions/integer.2'),
+                opt=self.rnd.default()
+            )
+            self.assertTrue(isinstance(i, six.integer_types), 'should be integer, not {0}'.format(i))
+
     def test_float(self):
         for _ in six.moves.xrange(50):
             f = self.rnd.render(
@@ -133,6 +141,14 @@ class OtherTestCase(unittest.TestCase):
             self.assertTrue(f <= 100, 'should be less than 100, not {0}'.format(f))
             self.assertTrue(f >= 50, 'should be greater than 50, not {0}'.format(f))
             self.assertTrue((f % 5) == 0, 'should be moduleable by 5, not {0}'.format(f))
+
+    def test_float_without_format(self):
+        for _ in six.moves.xrange(50):
+            f = self.rnd.render(
+                self.app.resolve('#/definitions/float.2'),
+                opt=self.rnd.default()
+            )
+            self.assertTrue(isinstance(f, float), 'should be float, not {0}'.format(f))
 
     def test_bool(self):
         b = self.rnd.render(


### PR DESCRIPTION
To fix this [issue](https://github.com/mission-liao/pyswagger/issues/144)